### PR TITLE
Fix unsafe pointer conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,5 @@ this repository, see https://golang.org/doc/contribute.html.
 The main issue tracker for the sys repository is located at
 https://github.com/golang/go/issues. Prefix your issue with "x/sys:" in the
 subject line, so it is easy to find.
+
+This is a fork

--- a/windows/svc/service.go
+++ b/windows/svc/service.go
@@ -210,7 +210,7 @@ var theService service // This is, unfortunately, a global, which means only one
 // serviceMain is the entry point called by the service manager, registered earlier by
 // the call to StartServiceCtrlDispatcher.
 func serviceMain(argc uint32, argv **uint16) uintptr {
-	handle, err := windows.RegisterServiceCtrlHandlerEx(windows.StringToUTF16Ptr(theService.name), ctlHandlerCallback, uintptr(unsafe.Pointer(&theService)))
+	handle, err := windows.RegisterServiceCtrlHandlerEx(windows.StringToUTF16Ptr(theService.name), ctlHandlerCallback, unsafe.Pointer(&theService))
 	if sysErr, ok := err.(windows.Errno); ok {
 		return uintptr(sysErr)
 	} else if err != nil {

--- a/windows/svc/service.go
+++ b/windows/svc/service.go
@@ -199,9 +199,8 @@ var (
 )
 
 func ctlHandler(ctl, evtype, evdata, context uintptr) uintptr {
-	s := (*service)(unsafe.Pointer(context))
 	e := ctlEvent{cmd: Cmd(ctl), eventType: uint32(evtype), eventData: evdata, context: 123456} // Set context to 123456 to test issue #25660.
-	s.c <- e
+	theService.c <- e
 	return 0
 }
 

--- a/windows/zsyscall_windows.go
+++ b/windows/zsyscall_windows.go
@@ -1175,7 +1175,7 @@ func RegisterEventSource(uncServerName *uint16, sourceName *uint16) (handle Hand
 	return
 }
 
-func RegisterServiceCtrlHandlerEx(serviceName *uint16, handlerProc uintptr, context uintptr) (handle Handle, err error) {
+func RegisterServiceCtrlHandlerEx(serviceName *uint16, handlerProc uintptr, context unsafe.Pointer) (handle Handle, err error) {
 	r0, _, e1 := syscall.Syscall(procRegisterServiceCtrlHandlerExW.Addr(), 3, uintptr(unsafe.Pointer(serviceName)), uintptr(handlerProc), uintptr(context))
 	handle = Handle(r0)
 	if handle == 0 {


### PR DESCRIPTION
I couldn't change the code that generates the `RegisterServiceCtrlHandlerEx` function because it was part of a different package and I couldn't figure out how to easily export a `*service`.  

Would also like to know if I did this fork properly (do I need to add permissions or something to protect this repo.